### PR TITLE
Configure publishing to maven central

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ fetch the required results.
 
 ## EMR Versions
 
-* HiveDdbQueryUDTF 0.9.0 was written to work with EMR release 5.32+
+* HiveDdbQueryUDTF 1.x.y was written to work with EMR release 5.32+
 * EMR release 6+ is still not supported, but should be coming soon. 
 
 ## How to use
@@ -47,7 +47,7 @@ First, the HiveDdbQueryUDTF jar should be available to your EMR cluster, either 
 `usr/lib/hive/auxlib/` or calling `add jar` during SQL execution.
 
 ```sql
-add jar s3://<your-bucket>/path/to/hiveddbudtf-0.9.0-SNAPSHOT.jar;
+add jar s3://<your-bucket>/path/to/hiveddbudtf-x.y.z.jar;
 ```
 
 Second, initialize HiveDdbQueryUdtf as a function, you can choose the function name

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
 		<java.version>1.8</java.version>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -2,16 +2,44 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.klimber.hiveddbudtf</groupId>
-	<artifactId>hiveddbudtf</artifactId>
-	<version>0.9.0-SNAPSHOT</version>
-	<name>HiveDdbUdtf</name>
-	<description>Hive User Defined Table Function for DynamoDB queries</description>
+	<groupId>io.github.klimber</groupId>
+	<artifactId>hive-ddb-query-udtf</artifactId>
+	<version>1.0.0</version>
+	<packaging>jar</packaging>
+
+	<name>HiveDdbQueryUDTF</name>
+	<description>Apache Hive user defined table function (UDTF) that allows querying
+		an Amazon DynamoDB table from Amazon EMR using SQL. </description>
+	<url>https://github.com/klimber/HiveDdbQueryUDTF</url>
+
+	<licenses>
+		<license>
+			<name>The Apache License, Version 2.0</name>
+			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+		</license>
+	</licenses>
+
+	<developers>
+		<developer>
+			<name>Allan Krueger</name>
+			<email>klimber.mail@gmail.com</email>
+			<organization>klimber</organization>
+			<organizationUrl>https://github.com/klimber</organizationUrl>
+		</developer>
+	</developers>
+
+	<scm>
+		<connection>scm:git:git://github.com/klimber/HiveDdbQueryUDTF.git</connection>
+		<developerConnection>scm:git:ssh://github.com:klimber/HiveDdbQueryUDTF.git</developerConnection>
+		<url>https://github.com/klimber/HiveDdbQueryUDTF/tree/main</url>
+	</scm>
+
 	<properties>
 		<java.version>1.8</java.version>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>io.github.hiverunner</groupId>
@@ -46,7 +74,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.28</version>
+			<version>1.18.34</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>
@@ -81,7 +109,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.11.0</version>
+				<version>3.12.1</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>
@@ -103,7 +131,63 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>2.2.1</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>2.10.3</version>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-gpg-plugin</artifactId>
+				<version>3.2.4</version>
+				<executions>
+					<execution>
+						<id>sign-artifacts</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>sign</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.sonatype.central</groupId>
+				<artifactId>central-publishing-maven-plugin</artifactId>
+				<version>0.5.0</version>
+				<extensions>true</extensions>
+				<configuration>
+					<publishingServerId>central</publishingServerId>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
+	<repositories>
+		<repository>
+			<id>maven_central</id>
+			<name>Maven Central</name>
+			<url>https://repo.maven.apache.org/maven2/</url>
+		</repository>
+	</repositories>
 
 </project>

--- a/src/main/java/com/klimber/hiveddbudtf/client/ddb/DynamoDbTypeFinder.java
+++ b/src/main/java/com/klimber/hiveddbudtf/client/ddb/DynamoDbTypeFinder.java
@@ -7,9 +7,9 @@ import org.apache.hadoop.hive.dynamodb.type.HiveDynamoDBType;
 import org.apache.hadoop.hive.dynamodb.type.HiveDynamoDBTypeFactory;
 
 /**
- * AWS SDKv2 has a <a
- * href="https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/dynamodb/model/AttributeValue
- * .html#type()">type</a> method to help discover which kind of attribute was returned from the API. This method does
+ * AWS SDKv2 has a
+ * <a href="https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/dynamodb/model/AttributeValue.html#type()">type</a>
+ * method to help discover which kind of attribute was returned from the API. This method does
  * not exist on SDKv1, so we have to rely on checking null fields.
  */
 @UtilityClass


### PR DESCRIPTION
This modifies pom.xml to publish jars to maven central:
* Change groupId to `io.github.klimber`
* Change artifactId to `hive-ddb-query-udtf`
* Set version to 1.0.0
* Update description
* Add license details
* Add developer information
* Add source control information
* Added `maven-source-plugin` for including sources
* Added `maven-javadoc-plugin` for including javadocs
* Added `maven-gpg-plugin` for GPG key signing
* Added `central-publishing-maven-plugin` to publish artifacts to maven central
* Added `maven_central` repository

Also includes other minor changes to `pom.xml`, `DynamoDbTypeFinder` and README